### PR TITLE
update pom.xml: specify minimal maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- disable the jar plugin because we need the assembly plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
According to https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
3.0.5 is not enforced, but a recommended version, that doubles as a minimum.

fixes #47

This one should not be merged unless 3.0.5 is still the recommended maven version,
even though some used plugins might profit from a newer release.
As soon as there's a decision, I'll update this PR.